### PR TITLE
Updated base.less

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -1,57 +1,61 @@
 @import "syntax-variables";
 
-.editor, :host {
+atom-text-editor, :host {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
   -webkit-filter: contrast(@contrast);
   -webkit-filter: saturate(@saturation);
+
+  .invisible-character {
+    color: @syntax-invisible-character-color;
+  }
+
+  .indent-guide {
+    color: @syntax-indent-guide-color;
+  }
+
+  .wrap-guide {
+    color: @syntax-wrap-guide-color;
+  }
+
+  .gutter {
+    background-color: @syntax-gutter-background-color;
+    color: @syntax-gutter-text-color;
+
+    .line-number {
+      &.cursor-line {
+        background-color: @syntax-gutter-background-color-selected;
+        color: @syntax-gutter-text-color-selected;
+      }
+
+      &.cursor-line-no-selection {
+        color: @syntax-gutter-text-color-selected;
+      }
+    }
+  }
+
+  .search-results .marker .region {
+    background-color: transparent;
+    border: @syntax-result-marker-color;
+  }
+
+  .search-results .marker.current-result .region {
+    border: @syntax-result-marker-color-selected;
+  }
 }
 
-.editor .gutter, :host .gutter {
-  background-color: @syntax-gutter-background-color;
-  color: @syntax-gutter-text-color;
-}
+atom-text-editor.is-focused, :host {
+  .cursor {
+    border-color: @syntax-cursor-color;
+  }
 
-.editor .gutter .line-number.cursor-line, :host .gutter .line-number.cursor-line {
-  background-color: @syntax-gutter-background-color-selected;
-  color: @syntax-gutter-text-color-selected;
-}
+  .selection .region {
+    background-color: @syntax-selection-color;
+  }
 
-.editor .gutter .line-number.cursor-line-no-selection, :host .gutter .line-number.cursor-line-no-selection {
-  color: @syntax-gutter-text-color-selected;
-}
-
-.editor .wrap-guide, :host .wrap-guide {
-  color: @syntax-wrap-guide-color;
-}
-
-.editor .indent-guide, :host .indent-guide {
-  color: @syntax-indent-guide-color;
-}
-
-.editor .invisible-character, :host .invisible-character {
-  color: @syntax-invisible-character-color;
-}
-
-.editor .search-results .marker .region, :host .search-results .marker .region {
-  background-color: transparent;
-  border: @syntax-result-marker-color;
-}
-
-.editor .search-results .marker.current-result .region, :host .search-results .marker.current-result .region {
-  border: @syntax-result-marker-color-selected;
-}
-
-.editor.is-focused .cursor, :host .cursor {
-  border-color: @syntax-cursor-color;
-}
-
-.editor.is-focused .selection .region, :host .selection .region {
-  background-color: @syntax-selection-color;
-}
-
-.editor.is-focused .line-number.cursor-line-no-selection, .editor.is-focused .line.cursor-line, :host .line-number.cursor-line-no-selection, :host .line.cursor-line {
-  background-color: #282828;
+  .line-number.cursor-line-no-selection, .line.cursor-line {
+    background-color: #282828;
+  }
 }
 
 .comment {
@@ -91,29 +95,9 @@
   text-shadow: 0px 0px @blur rgba(203, 175, 108, @opacity);
 }
 
-.entity.name.function {
-  color: rgba(18, 255, 169, 0.97);
-  text-shadow: 0px 0px @blur rgba(34, 255, 169, @opacity);
-}
-
 .support.function {
   color: #ADAeB2;
   text-shadow: 0px 0px @blur rgba(189, 190, 130, @opacity);
-}
-
-.entity.name.function.misc {
-  color: #E3E4A9;
-  text-shadow: 0px 0px @blur rgba(227, 228, 169, @opacity);
-}
-
-.entity.name.function.predicate {
-  color: #A5DF93;
-  text-shadow: 0px 0px @blur rgba(165, 223, 147, @opacity);
-}
-
-.entity.name.function.io {
-  color: #DFB3AC;
-  text-shadow: 0px 0px @blur rgba(223, 179, 172, @opacity);
 }
 
 .variable.other.external-symbol {
@@ -136,19 +120,51 @@
   text-shadow: 0px 0px @blur rgba(155, 159, 253, @opacity);
 }
 
-.entity.name.class {
-  color: #B998DF;
-  text-shadow: 0px 0px @blur rgba(185, 152, 223, @opacity);
-}
+.entity {
+  &.name.type {
+    color: rgba(175, 119, 169, 0.93);
+    text-shadow: 0px 0px @blur rgba(175, 119, 169, @opacity);
+  }
 
-.entity.name.structure {
-  color: rgba(34, 255, 153, 0.87);
-  text-shadow: 0px 0px @blur rgba(185, 152, 223, @opacity);
-}
+  &.name.class {
+    color: #B998DF;
+    text-shadow: 0px 0px @blur rgba(185, 152, 223, @opacity);
+  }
 
-.entity.name.type {
-  color: rgba(175, 119, 169, 0.93);
-  text-shadow: 0px 0px @blur rgba(175, 119, 169, @opacity);
+  &.name.structure {
+    color: rgba(34, 255, 153, 0.87);
+    text-shadow: 0px 0px @blur rgba(185, 152, 223, @opacity);
+  }
+
+  &.name.tag {
+    color: #49a6d2;
+    text-shadow: 0px 0px @blur rgba(73, 166, 210, @opacity);
+  }
+
+  &.name.function {
+    color: rgba(18, 255, 169, 0.97);
+    text-shadow: 0px 0px @blur rgba(34, 255, 169, @opacity);
+  }
+
+  &.name.function.io {
+    color: #DFB3AC;
+    text-shadow: 0px 0px @blur rgba(223, 179, 172, @opacity);
+  }
+
+  &.name.function.misc {
+    color: #E3E4A9;
+    text-shadow: 0px 0px @blur rgba(227, 228, 169, @opacity);
+  }
+
+  &.name.function.predicate {
+    color: #A5DF93;
+    text-shadow: 0px 0px @blur rgba(165, 223, 147, @opacity);
+  }
+
+  &.other.attribute-name {
+    color: rgba(73, 134, 194, 0.8);
+    text-shadow: 0px 0px @blur rgba(73, 134, 194, @opacity);
+  }
 }
 
 .meta.class, .entity.name.class, .entity.name.type.class {
@@ -175,11 +191,6 @@
 .entity.name.tag {
   color: #49a6d2;
   text-shadow: 0px 0px @blur rgba(73, 166, 210, @opacity);
-}
-
-.entity.other.attribute-name {
-  color: rgba(73, 134, 194, 0.8);
-  text-shadow: 0px 0px @blur rgba(73, 134, 194, @opacity);
 }
 
 .markup.heading {


### PR DESCRIPTION
Resolves atom’s warning regarding using `.editor` class rather than
`atom-text-editor` selector. This is also an upgrade according to [official atom.io documentation](https://github.com/atom/atom/blob/master/docs/upgrading/upgrading-your-syntax-theme.md).

Selectors are now nested when necessary to increase readability and scalability.